### PR TITLE
docs(eshell): fix +eshell/here docstring

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
       + [ ] Search [the issue tracker](https://github.com/hlissner/doom-emacs/issues) for similar issues (the closed issues too).
       + [ ] Search [the Discourse](https://discourse.doomemacs.org) for any errors and solutions.
       + [ ] Ensure the issue can be reproduced on [the latest commit](https://github.com/hlissner/doom-emacs/commit) of Doom Emacs.
-      + [ ] Consult [our troubleshooting](https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org#troubleshoot) on techniques to get more information and, possibly, solve the issue yourself.
+      + [ ] Consult [our troubleshooting](https://github.com/hlissner/doom-emacs/blob/master/docs/getting_started.org#troubleshoot) on techniques to get more information and, possibly, solve the issue yourself.
 - type: textarea
   attributes:
     label: What did you expect to happen?
@@ -28,7 +28,7 @@ body:
     label: What actually happened?
     description: |
       + Include screenshots/casts, if possible
-      + List *all* error messages and **[include backtraces for each of them](https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org#how-to-extract-a-backtrace-from-an-error)
+      + List *all* error messages and **[include backtraces for each of them](https://github.com/hlissner/doom-emacs/blob/master/docs/getting_started.org#how-to-extract-a-backtrace-from-an-error)
       + Include any suspicious logs in the **[\*Messages\*](https://doomemacs.org/d/t/55) buffer.
       + If you include log dumps, please use [pastebin.com](https://pastebin.com)
       + **Use [code fences](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) for code, error messages, and backtraces.**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@
   YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
   FOLLOWING CRITERIA:
 
-  - [ ] It targets the develop branch
   - [ ] No other pull requests exist for this issue
   - [ ] The issue is NOT in Doom's do-not-PR list: https://gist.github.com/hlissner/bb6365626d825aeaf5e857b1c03c9837
   - [ ] Any relevant issues and PRs have been linked to

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,7 @@ on:
       - '.dir-locals.el'
       - 'LICENSE'
     branches:
-      - main
-      - develop
+      - master
 
 jobs:
   unix-test:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ![Made with Doom Emacs](https://img.shields.io/github/tag/hlissner/doom-emacs.svg?style=flat-square&label=release&color=58839b)
 ![Minimum Emacs version supported: 27.1](https://img.shields.io/badge/Emacs-27.1+-blueviolet.svg?style=flat-square&logo=GNU%20Emacs&logoColor=white)
-![Latest commit](https://img.shields.io/github/last-commit/hlissner/doom-emacs/develop?style=flat-square)
-![Build status: develop](https://img.shields.io/github/workflow/status/hlissner/doom-emacs/CI/develop?style=flat-square)
+![Latest commit](https://img.shields.io/github/last-commit/hlissner/doom-emacs/master?style=flat-square)
+![Build status: master](https://img.shields.io/github/workflow/status/hlissner/doom-emacs/CI/master?style=flat-square)
 [![Discord Server](https://img.shields.io/discord/406534637242810369?color=738adb&label=Discord&logo=discord&logoColor=white&style=flat-square)][Discord]
 [![Discourse server](https://img.shields.io/discourse/users?server=https%3A%2F%2Fdiscourse.doomemacs.org&logo=discourse&label=Discourse&style=flat-square&color=9cf)][Discourse]
 

--- a/modules/app/rss/autoload.el
+++ b/modules/app/rss/autoload.el
@@ -8,7 +8,7 @@
   (interactive)
   (if (featurep! :ui workspaces)
       (progn
-        (+workspace-switch "rss" t)
+        (+workspace-switch "*rss*" t)
         (doom/switch-to-scratch-buffer)
         (elfeed)
         (+workspace/display))

--- a/modules/completion/vertico/README.org
+++ b/modules/completion/vertico/README.org
@@ -79,15 +79,16 @@ Doom-specific additions:
 When in an active Vertico completion session, the following doom added
 keybindings are available:
 
-| Keybind               | Description                                        |
-|-----------------------+----------------------------------------------------|
-| =C-k=                 | (evil) Go to previous candidate                    |
-| =C-j=                 | (evil) Go to next candidate                        |
-| =C-M-k=               | (evil) Go to previous group                        |
-| =C-M-j=               | (evil) Go to next group                            |
-| =C-;= or =<leader> a= | Open an ~embark-act~ menu to chose a useful action |
-| =C-c C-;=             | export the current candidate list to a buffer      |
-| =C-SPC=               | Preview the current candidate                      |
+| Keybind               | Description                                                                   |
+|-----------------------+-------------------------------------------------------------------------------|
+| =C-k=                 | (evil) Go to previous candidate                                               |
+| =C-j=                 | (evil) Go to next candidate                                                   |
+| =C-M-k=               | (evil) Go to previous group                                                   |
+| =C-M-j=               | (evil) Go to next group                                                       |
+| =C-;= or =<leader> a= | Open an ~embark-act~ menu to chose a useful action                            |
+| =C-c C-;=             | ~embark-export~ the current candidate list (export to a type-specific buffer) |
+| =C-c C-s=             | ~embark-collect-snapsnot~ the current candidate list (collect verbatim)       |
+| =C-SPC=               | Preview the current candidate                                                 |
 
 ~embark-act~ will prompt you with a =which-key= menu with useful commands on the
 selected candidate or candidate list, depending on the completion category. Note

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -131,6 +131,7 @@ orderless."
    +default/search-project-for-symbol-at-point
    +default/search-cwd +default/search-other-cwd
    +default/search-notes-for-symbol-at-point
+   +default/search-emacsd
    consult--source-file consult--source-project-file consult--source-bookmark
    :preview-key (kbd "C-SPC"))
   (consult-customize

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -172,6 +172,7 @@ orderless."
         (:map minibuffer-local-map
          "C-;"               #'embark-act
          "C-c C-;"           #'embark-export
+         "C-c C-s"           #'embark-collect-snapshot
          :desc "Export to writable buffer" "C-c C-e" #'+vertico/embark-export-write)
         (:leader
          :desc "Actions" "a" #'embark-act)) ; to be moved to :config default if accepted

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -205,11 +205,11 @@ orderless."
     ("u" doom/help-package-homepage))
   (setf (alist-get 'package embark-keymap-alist) #'+vertico/embark-doom-package-map)
   (map! (:map embark-file-map
-         :desc "Open target with sudo" "s" #'doom/sudo-find-file
+         :desc "Open target with sudo"        "s"   #'doom/sudo-find-file
          (:when (featurep! :tools magit)
           :desc "Open magit-status of target" "g"   #'+vertico/embark-magit-status)
          (:when (featurep! :ui workspaces)
-          :desc "Open in new workspace" "TAB" #'+vertico/embark-open-in-new-workspace))))
+          :desc "Open in new workspace"       "TAB" #'+vertico/embark-open-in-new-workspace))))
 
 
 (use-package! marginalia

--- a/modules/completion/vertico/config.el
+++ b/modules/completion/vertico/config.el
@@ -146,7 +146,8 @@ orderless."
         :items    ,(lambda () (mapcar #'buffer-name (org-buffer-list)))))
     (add-to-list 'consult-buffer-sources '+vertico--consult-org-source 'append))
   (map! :map consult-crm-map
-        :desc "Select candidate" "TAB" #'+vertico/crm-select
+        :desc "Select candidate" [tab] #'+vertico/crm-select
+        :desc "Select candidate and keep input" [backtab] #'+vertico/crm-select-keep-input
         :desc "Enter candidates" "RET" #'+vertico/crm-exit))
 
 

--- a/modules/completion/vertico/packages.el
+++ b/modules/completion/vertico/packages.el
@@ -4,21 +4,21 @@
 (package! vertico
   :recipe (:host github :repo "minad/vertico"
            :files ("*.el" "extensions/*.el"))
-  :pin "eedcb847869226701acaf9a36dce0a51d1b60862")
+  :pin "a8fe9a0b2e156e022136169a3159b4dad78b2439")
 
 (package! orderless :pin "1ccf74ffdbb0dd34caa63022e92f947c09c49c86")
 
-(package! consult :pin "cc8eff9578f5d089735e8b7dd7a08732890ed648")
+(package! consult :pin "0940ca016531f3412003c231b476e5023a510ff9")
 (package! consult-dir :pin "08f543ae6acbfc1ffe579ba1d00a5414012d5c0b")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "0ad7e8ff15683a4d64b79c29b3fcf847edfe244b"))
 
-(package! embark :pin "e08899ef2e7fb9c1ed4b4b21e44cd368561f91f9")
-(package! embark-consult :pin "e08899ef2e7fb9c1ed4b4b21e44cd368561f91f9")
+(package! embark :pin "c9b26c2e18f01ae401df6a69b7a0c1a6bc44b90c")
+(package! embark-consult :pin "c9b26c2e18f01ae401df6a69b7a0c1a6bc44b90c")
 
-(package! marginalia :pin "2fb2787bc302a5533e09bc558c76eb914e98543b")
+(package! marginalia :pin "9229d88ae4757f3439e81f51799758c009838cb4")
 
 (package! wgrep :pin "f9687c28bbc2e84f87a479b6ce04407bb97cfb23")
 
 (when (featurep! +icons)
-  (package! all-the-icons-completion :pin "a0f34d68cc12330ab3992a7521f9caa1de3b8470"))
+  (package! all-the-icons-completion :pin "9e7d456b0934ecb568b6f05a8445e3f4ce32261f"))

--- a/modules/lang/dart/packages.el
+++ b/modules/lang/dart/packages.el
@@ -4,7 +4,7 @@
 (package! dart-mode :pin "3bac14200f9f8f8fcebc383087572da5c3823c34")
 
 (when (featurep! +lsp)
-  (package! lsp-dart :pin "64fb5d93038483abab59751200749ad81698a845"))
+  (package! lsp-dart :pin "813d3c92db02596a8e8aa7802977c50ec1262f9d"))
 
 (when (featurep! +flutter)
   (package! flutter :pin "81c524a43c46f4949ccde3b57e2a6ea359f712f4")

--- a/modules/lang/haskell/doctor.el
+++ b/modules/lang/haskell/doctor.el
@@ -17,8 +17,9 @@
   Install it or enable +lsp."))
 
 (when (and (featurep! :editor format)
+           (not (featurep! +lsp))
            (not (executable-find "brittany")))
-      (warn! "Couldn't find brittany. Code formatting will not work.
+  (warn! "Couldn't find brittany. Code formatting will not work.
   Install it or enable +lsp."))
 
 (when (and (featurep! +lsp)

--- a/modules/term/eshell/autoload/eshell.el
+++ b/modules/term/eshell/autoload/eshell.el
@@ -113,7 +113,7 @@
 
 ;;;###autoload
 (defun +eshell/here (&optional command)
-  "Open eshell in the current buffer."
+  "Open eshell in the current window."
   (interactive "P")
   (let ((buf (+eshell--unused-buffer)))
     (with-current-buffer (switch-to-buffer buf)


### PR DESCRIPTION
This PR corrects a mistake in the function docstring for `+eshell/here`. The docstring says that this function opens Eshell in the current buffer rather. In reality, a new buffer is created for Eshell and displayed in the current window.
